### PR TITLE
Make the CIUser permission optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ modules_[AWS_ACCOUNT_NAME].tf
     index   = "Splunk index name"
 
     dev_account = "true"
+    ci_account  = "true"
 
     # Enable whole-service Rules
     securityhub_rules = "true"
@@ -226,6 +227,18 @@ dev_account
     Set to "true" if target is a development Account
     default     = "false"
     type        = string
+
+ci_account
+-
+    Set to "true" if CI user IAM policy is to be created
+    default     = "true"
+    type        = string
+
+ci_principals
+-
+    Allows a consumer to override the default CI account principals
+    default     = []
+    type        = list(string)
 
 guardduty_hec_token
 -

--- a/iam.tf
+++ b/iam.tf
@@ -607,15 +607,18 @@ data "aws_iam_policy_document" "s3_bucket_cmk" {
       type        = "AWS"
     }
   }
-  statement {
-    sid       = "EnableIAMPermissionsCIUser"
-    effect    = "Allow"
-    actions   = ["kms:*"]
-    resources = ["*"]
+  dynamic "statement" {
+    for_each = var.ci_account == "true" ? [""] : []
+    content {
+      sid       = "EnableIAMPermissionsCIUser"
+      effect    = "Allow"
+      actions   = ["kms:*"]
+      resources = ["*"]
 
-    principals {
-      identifiers = local.ci_principals
-      type        = "AWS"
+      principals {
+        identifiers = local.ci_principals
+        type        = "AWS"
+      }
     }
   }
   dynamic "statement" {

--- a/variables.tf
+++ b/variables.tf
@@ -593,6 +593,12 @@ variable "dev_account" {
   type        = string
 }
 
+variable "ci_account" {
+  description = "A flag to identify if this is a CI Account"
+  default     = "true"
+  type        = string
+}
+
 variable "ci_principals" {
   description = "A list of principals that should be assigned CI user IAM policies"
   default     = []


### PR DESCRIPTION
### Description

Further to #52 which makes it possible to configure the identities for the CI user, this PR extends the functionality to make the policy statement that grants permissions to KMS for the CI user/role optional in the case where it is not required.

The previous change grants any principal passed in full access to all KMS resources. For DP requirements there is no clear CI user/role to pass in and so it would be nice to not have to provide a value by setting the `ci_account = "false"`. Defaulting to `true` to ensure backwards compatibility. 